### PR TITLE
Fix gcloud functions describe call

### DIFF
--- a/main.go
+++ b/main.go
@@ -461,7 +461,6 @@ func main() {
 		// 				This variant is also available:
 
 		logInfo("Describing cloud function %v...", params.App)
-		
 
 		describeArguments := []string{
 			"functions",

--- a/main.go
+++ b/main.go
@@ -461,7 +461,14 @@ func main() {
 		// 				This variant is also available:
 
 		logInfo("Describing cloud function %v...", params.App)
-		runCommand("gcloud", []string{"functions", "describe", params.App})
+		
+
+		describeArguments := []string{
+			"functions",
+			"describe", params.App,
+			"--region", credential.AdditionalProperties.Region}
+
+		runCommand("gcloud", describeArguments)
 	}
 }
 


### PR DESCRIPTION
The `gcloud functions describe <name>` call was being executed using the default region from the gcloud cli. This pull requests makes it use the same used when the cloud function was created.