### PR TITLE
env-vars argument

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -47,7 +47,7 @@ stages:
     runtime: go111
     timeout: 60
     source: .
-    env:
+    env-vars:
       MYENVVAR: somevalue
       MYSECRET: estafette.secret(YjTy7bw294jSfUSt.xEPLb_pRjmVCLFosptSzmOeBwc63INN7bIcP)
     memory: 256MB

--- a/main.go
+++ b/main.go
@@ -50,7 +50,6 @@ func main() {
 	// log startup message
 	logInfo("Starting %v version %v...", app, version)
 
-    logInfo("paramsJSON: %v ", paramsJSON)
 	// put all estafette labels in map
 	logInfo("Getting all estafette labels from envvars...")
 	estafetteLabels := map[string]string{}

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 	// log startup message
 	logInfo("Starting %v version %v...", app, version)
 
+    logInfo("paramsJSON: %v ", paramsJSON)
 	// put all estafette labels in map
 	logInfo("Getting all estafette labels from envvars...")
 	estafetteLabels := map[string]string{}

--- a/params.go
+++ b/params.go
@@ -16,7 +16,7 @@ type Params struct {
 	Memory               string                 `json:"memory,omitempty"`
 	Source               string                 `json:"source,omitempty"`
 	TimeoutSeconds       int                    `json:"timeout,omitempty"`
-	EnvironmentVariables map[string]interface{} `json:"env,omitempty"`
+	EnvironmentVariables map[string]interface{} `json:"env-vars,omitempty"`
 }
 
 // SetDefaults fills in empty fields with convention-based defaults


### PR DESCRIPTION
Change the custom property name used for the set-env-vars argument because the variables set in env are not included in the stage.CustomProperties variable