### PR TITLE
Add trigger and triggerValue params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# IntelliJ IDE ignore
+.idea

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # estafette-extension-cloud-function
-This extension can be used to create and deploy a cloud function
+This extension can be used to create and deploy a cloud function, the default trigger is HTTP.
 
 # Usage
+
+HTTP trigger
 
 ```
 releases:
@@ -12,4 +14,19 @@ releases:
                 image: extensions/cloud-function:stable
                 runtime: go111
                 memory: 256MB
+```
+
+Bucket trigger
+
+```
+releases:
+    development:
+        clone: true
+        stages:
+            deploy:
+                image: extensions/cloud-function:stable
+                runtime: go111
+                memory: 256MB
+                trigger: bucket
+                triggerValue: bucketName
 ```

--- a/main.go
+++ b/main.go
@@ -190,7 +190,7 @@ func main() {
 		arguments = append(arguments, "--service-account", params.ServiceAccount)
 	}
 
-	if params.Trigger == "--trigger-bucket" {
+	if params.Trigger == "bucket" {
 	    arguments = append(arguments, "--trigger-bucket", params.TriggerValue)
 	} else {
 	    arguments = append(arguments, "--trigger-http")

--- a/main.go
+++ b/main.go
@@ -173,8 +173,7 @@ func main() {
 		"--source", params.Source,
 		"--timeout", fmt.Sprintf("%vs", params.TimeoutSeconds),
 		"--runtime", params.Runtime,
-		"--update-labels", strings.Join(labelParams, ","),
-		"--trigger-http"}
+		"--update-labels", strings.Join(labelParams, ",")}
 
 	if len(params.EnvironmentVariables) > 0 {
 
@@ -189,6 +188,12 @@ func main() {
 
 	if params.ServiceAccount != "" {
 		arguments = append(arguments, "--service-account", params.ServiceAccount)
+	}
+
+	if params.Trigger == "--trigger-bucket" {
+	    arguments = append(arguments, "--trigger-bucket", params.TriggerValue)
+	} else {
+	    arguments = append(arguments, "--trigger-http")
 	}
 
 	if params.DryRun {

--- a/params.go
+++ b/params.go
@@ -14,7 +14,7 @@ type Params struct {
 	App                  string                 `json:"app,omitempty"`
 	Runtime              string                 `json:"runtime,omitempty"`
 	Trigger              string                 `json:"trigger,omitempty"`
-	TriggerValue         string                 `json:"TriggerValue,omitempty"`
+	TriggerValue         string                 `json:"triggerValue,omitempty"`
 	Memory               string                 `json:"memory,omitempty"`
 	ServiceAccount       string                 `json:serviceAccount,omitempty"`
 	Source               string                 `json:"source,omitempty"`

--- a/params.go
+++ b/params.go
@@ -13,6 +13,8 @@ type Params struct {
 	// app params
 	App                  string                 `json:"app,omitempty"`
 	Runtime              string                 `json:"runtime,omitempty"`
+	Trigger              string                 `json:"trigger,omitempty"`
+	TriggerValue         string                 `json:"TriggerValue,omitempty"`
 	Memory               string                 `json:"memory,omitempty"`
 	ServiceAccount       string                 `json:serviceAccount,omitempty"`
 	Source               string                 `json:"source,omitempty"`
@@ -29,6 +31,11 @@ func (p *Params) SetDefaults(gitName, appLabel, buildVersion, releaseName, relea
 	}
 	if p.App == "" && appLabel != "" {
 		p.App = appLabel
+	}
+
+	// default trigger to http-trigger
+	if p.Trigger == "" {
+		p.Trigger = "trigger-http"
 	}
 
 	// default memory to 256MB
@@ -74,6 +81,19 @@ func (p *Params) ValidateRequiredProperties() (bool, []error, []string) {
 
 	if !inStringArray(p.Memory, supportedMemory) {
 		errors = append(errors, fmt.Errorf("Memory %v is not supported; set it to %v", p.Memory, strings.Join(supportedMemory, ", ")))
+	}
+
+	supportedTrigger := []string{
+		"trigger-http",
+		"trigger-bucket",
+	}
+
+	if !inStringArray(p.Trigger, supportedTrigger) {
+		errors = append(errors, fmt.Errorf("Trigger %v is not supported; set it to %v", p.Trigger, strings.Join(supportedTrigger, ", ")))
+	}
+
+	if p.Trigger == "trigger-bucket" && p.TriggerValue == "" {
+		errors = append(errors, fmt.Errorf("TriggerValue is required when Trigger is trigger-bucket; set TriggerValue as well"))
 	}
 
 	if p.TimeoutSeconds <= 0 || p.TimeoutSeconds > 540 {

--- a/params.go
+++ b/params.go
@@ -35,7 +35,7 @@ func (p *Params) SetDefaults(gitName, appLabel, buildVersion, releaseName, relea
 
 	// default trigger to http-trigger
 	if p.Trigger == "" {
-		p.Trigger = "trigger-http"
+		p.Trigger = "http"
 	}
 
 	// default memory to 256MB
@@ -84,16 +84,16 @@ func (p *Params) ValidateRequiredProperties() (bool, []error, []string) {
 	}
 
 	supportedTrigger := []string{
-		"trigger-http",
-		"trigger-bucket",
+		"http",
+		"bucket",
 	}
 
 	if !inStringArray(p.Trigger, supportedTrigger) {
 		errors = append(errors, fmt.Errorf("Trigger %v is not supported; set it to %v", p.Trigger, strings.Join(supportedTrigger, ", ")))
 	}
 
-	if p.Trigger == "trigger-bucket" && p.TriggerValue == "" {
-		errors = append(errors, fmt.Errorf("TriggerValue is required when Trigger is trigger-bucket; set TriggerValue as well"))
+	if p.Trigger == "bucket" && p.TriggerValue == "" {
+		errors = append(errors, fmt.Errorf("TriggerValue is required when Trigger is bucket; set TriggerValue as well"))
 	}
 
 	if p.TimeoutSeconds <= 0 || p.TimeoutSeconds > 540 {

--- a/params_test.go
+++ b/params_test.go
@@ -100,7 +100,7 @@ func TestSetDefaults(t *testing.T) {
 
 	t.Run("KeepsTriggerIfNotEmpty", func(t *testing.T) {
 
-        trigger := "bucket"
+        	trigger := "bucket"
 		params := Params{
 			Trigger: trigger,
 		}

--- a/params_test.go
+++ b/params_test.go
@@ -89,16 +89,17 @@ func TestSetDefaults(t *testing.T) {
 	t.Run("DefaultsTriggerToHttp", func(t *testing.T) {
 
 		params := Params{
-			Trigger: "http",
+			Trigger: "",
 		}
 
 		// act
 		params.SetDefaults("", "", "", "", "", map[string]string{})
 
-		assert.Equal(t, "256MB", params.Memory)
+		assert.Equal(t, "http", params.Trigger)
 	})
 
 	t.Run("KeepsTriggerIfNotEmpty", func(t *testing.T) {
+
         trigger := "bucket"
 		params := Params{
 			Trigger: trigger,
@@ -188,7 +189,7 @@ func TestValidateRequiredProperties(t *testing.T) {
 	t.Run("ReturnsFalseIfTriggerValueIsEmptyForTriggerBucket", func(t *testing.T) {
 
 		params := validParams
-		params.Trigger = "trigger"
+		params.Trigger = "bucket"
 
 		// act
 		valid, errors, _ := params.ValidateRequiredProperties()
@@ -213,7 +214,7 @@ func TestValidateRequiredProperties(t *testing.T) {
 	t.Run("ReturnsFalseIfTriggerIsNotSupported", func(t *testing.T) {
 
 		params := validParams
-		params.Trigger = "bucket"
+		params.Trigger = "trigger"
 
 		// act
 		valid, errors, _ := params.ValidateRequiredProperties()

--- a/params_test.go
+++ b/params_test.go
@@ -12,7 +12,7 @@ var (
 	validParams = Params{
 		Runtime:        "go111",
 		Memory:         "256MB",
-		Trigger:        "trigger-http",
+		Trigger:        "http",
 		Source:         ".",
 		TimeoutSeconds: 60,
 	}
@@ -84,6 +84,30 @@ func TestSetDefaults(t *testing.T) {
 		params.SetDefaults("", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "128MB", params.Memory)
+	})
+
+	t.Run("DefaultsTriggerToHttp", func(t *testing.T) {
+
+		params := Params{
+			Trigger: "http",
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", "", map[string]string{})
+
+		assert.Equal(t, "256MB", params.Memory)
+	})
+
+	t.Run("KeepsTriggerIfNotEmpty", func(t *testing.T) {
+        trigger := "bucket"
+		params := Params{
+			Trigger: trigger,
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", "", map[string]string{})
+
+		assert.Equal(t, trigger, params.Trigger)
 	})
 
 	t.Run("DefaultsSourceToCurrentDirectory", func(t *testing.T) {
@@ -176,7 +200,7 @@ func TestValidateRequiredProperties(t *testing.T) {
 	t.Run("ReturnsTrueIfTriggerValueIsNotEmptyForTriggerBucket", func(t *testing.T) {
 
 		params := validParams
-		params.Trigger = "trigger-bucket"
+		params.Trigger = "bucket"
 		params.TriggerValue = "bucketName"
 
 		// act
@@ -189,7 +213,7 @@ func TestValidateRequiredProperties(t *testing.T) {
 	t.Run("ReturnsFalseIfTriggerIsNotSupported", func(t *testing.T) {
 
 		params := validParams
-		params.Trigger = "trigger-bucket"
+		params.Trigger = "bucket"
 
 		// act
 		valid, errors, _ := params.ValidateRequiredProperties()
@@ -201,7 +225,7 @@ func TestValidateRequiredProperties(t *testing.T) {
 	t.Run("ReturnsTrueIfTriggerIsSupported", func(t *testing.T) {
 
 		params := validParams
-		params.Trigger = "trigger-http"
+		params.Trigger = "http"
 
 		// act
 		valid, errors, _ := params.ValidateRequiredProperties()

--- a/params_test.go
+++ b/params_test.go
@@ -12,6 +12,7 @@ var (
 	validParams = Params{
 		Runtime:        "go111",
 		Memory:         "256MB",
+		Trigger:        "trigger-http",
 		Source:         ".",
 		TimeoutSeconds: 60,
 	}
@@ -160,6 +161,55 @@ func TestValidateRequiredProperties(t *testing.T) {
 		assert.True(t, len(errors) == 0)
 	})
 
+	t.Run("ReturnsFalseIfTriggerValueIsEmptyForTriggerBucket", func(t *testing.T) {
+
+		params := validParams
+		params.Trigger = "trigger"
+
+		// act
+		valid, errors, _ := params.ValidateRequiredProperties()
+
+		assert.False(t, valid)
+		assert.True(t, len(errors) > 0)
+	})
+
+	t.Run("ReturnsTrueIfTriggerValueIsNotEmptyForTriggerBucket", func(t *testing.T) {
+
+		params := validParams
+		params.Trigger = "trigger-bucket"
+		params.TriggerValue = "bucketName"
+
+		// act
+		valid, errors, _ := params.ValidateRequiredProperties()
+
+		assert.True(t, valid)
+		assert.True(t, len(errors) == 0)
+	})
+
+	t.Run("ReturnsFalseIfTriggerIsNotSupported", func(t *testing.T) {
+
+		params := validParams
+		params.Trigger = "trigger-bucket"
+
+		// act
+		valid, errors, _ := params.ValidateRequiredProperties()
+
+		assert.False(t, valid)
+		assert.True(t, len(errors) > 0)
+	})
+
+	t.Run("ReturnsTrueIfTriggerIsSupported", func(t *testing.T) {
+
+		params := validParams
+		params.Trigger = "trigger-http"
+
+		// act
+		valid, errors, _ := params.ValidateRequiredProperties()
+
+		assert.True(t, valid)
+		assert.True(t, len(errors) == 0)
+	})
+
 	t.Run("ReturnsFalseIfMemoryIsNotSupported", func(t *testing.T) {
 
 		params := validParams
@@ -172,7 +222,7 @@ func TestValidateRequiredProperties(t *testing.T) {
 		assert.True(t, len(errors) > 0)
 	})
 
-	t.Run("ReturnsTrueIfRuntimeIsSupported", func(t *testing.T) {
+	t.Run("ReturnsTrueIfMemoryIsSupported", func(t *testing.T) {
 
 		params := validParams
 		params.Memory = "512MB"


### PR DESCRIPTION
Add trigger and triggerValue params in order to be able to deploy google cloud functions which are triggered by Bucket rather than HTTP.

Changes:
- Add trigger and triggerValue params
- Add tests
- Fix typo in one of the test's title
- Add .idea directory to .gitignore
- Update README